### PR TITLE
[PIE-230] PR Template file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# These owners will be requested for
+# review when someone opens a pull request.
+*      @JH-HEALTHIT/HLT-PIE-admin
+
+# For more info see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# .github
+# Community Health - JH-HEALTHIT 
+
+This is the Community Health Repository for JH-HEALTHIT. It includes a landing page for the JH-HEALTHIT organization ([README.md](./profile/README.md)) and a [pull request template](./pull_request_template.md).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,3 @@
+# Johns Hopkins Health IT
+
+Welcome to the Johns Hopkins Health IT GitHub organization. If you believe that you need access to repositories in this organization, please contact the [PIE Team](mailto:hltpieteam@lists.jh.edu).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,17 @@
+**Jira Ticket**: \[[-](https://jira.jh.edu/browse/-)\]
+
+## What?
+
+- Describe how your PR changes the codebase and features in the repository.
+
+## Why?
+
+- Why are you making these changes?
+
+## Tested?
+
+- Did you test these changes? How?
+
+## Screenshots
+
+- Provide a screenshot demonstrating your changes in action.


### PR DESCRIPTION
**Jira Ticket**: \[[PIE-230](https://jira.jh.edu/browse/PIE-230)\]

## What?

- This creates a default PR template for all repositories, as well as a landing page instead of the default weird GitHub org page.

## Why?

- From PIE-230, we are testing this out in the JH-HEALTHIT organization.

## Tested?

- No, once this is implemented we can see how it works better.
